### PR TITLE
Added the requester Identity data as Tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 cdk.out
 .cdk_output
 .cfn_outputs
+resourcetagging/__pycache__

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Guide to Resource Tagging Automation
 This is a Lambda function that can auto tagging newly created AWS resources. It is triggered by EventBridge events from CloudTrail logs. Currently it supports tagging EC2, S3, DynamoDB, RDS, Lambda, EFS, EBS, ELB, OpenSearch, SNS, SQS, ElastiCache and KMS.
 
+The solution will Tag those supported resources with pre-defined tags and also (optionally) the identity used to deploy them for easier ownership and cost allocation.
+
 Notice that the solution can only tag newly created resources, if you want to tag resources already created, please go to AWS Tag Editor Console, https://console.aws.amazon.com/resource-groups/tag-editor/find-resources.
 
 If you want to deploy by CloudFormation, please refer https://github.com/aws-samples/resource-tagging-automation/tree/main/cloudformation.
@@ -57,6 +59,11 @@ $ cdk bootstrap
 $ cdk deploy --require-approval never --parameters tags='{"TagName1": "TagValue1","TagName2": "TagValue2"}'
 ```
 
+(Optional) You can also choose to disable the Identity Recording feature by definening the identityRecording parameter to false. This feature is enabled by default.
+
+```
+$ cdk deploy --require-approval never --parameters tags='{"TagName1": "TagValue1","TagName2": "TagValue2"}' --parameters identityRecording='false'
+```
 
 ### To check
 1. Configure AWS CLI, please refer https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ cdk bootstrap
 $ cdk deploy --require-approval never --parameters tags='{"TagName1": "TagValue1","TagName2": "TagValue2"}'
 ```
 
-(Optional) You can also choose to disable the Identity Recording feature by definening the identityRecording parameter to false. This feature is enabled by default.
+(Optional) You can also choose to disable the Identity Recording feature by definening the `identityRecording` parameter to false. This feature is enabled by default.
 
 ```
 $ cdk deploy --require-approval never --parameters tags='{"TagName1": "TagValue1","TagName2": "TagValue2"}' --parameters identityRecording='false'

--- a/lambda/lambda-handler.py
+++ b/lambda/lambda-handler.py
@@ -200,14 +200,16 @@ def main(event, context):
     print(resARNs)
     
     _res_tags =  json.loads(os.environ['tags'])
-    
-    if event['detail']['userIdentity']['type'] == 'AssumedRole':
-        _userId, _roleId = get_identity(event)
-        _res_tags['roleId'] = _roleId
-    else:
-        _userId = get_identity(event)
-    
-    _res_tags['userId'] = _userId
+    _identity_recording = os.environ['identityRecording']
+
+    if _identity_recording == 'true':
+        if event['detail']['userIdentity']['type'] == 'AssumedRole':
+            _userId, _roleId = get_identity(event)
+            _res_tags['roleId'] = _roleId
+        else:
+            _userId = get_identity(event)
+        
+        _res_tags['userId'] = _userId
     
     print(_res_tags)
     boto3.client('resourcegroupstaggingapi').tag_resources(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
+aws-cdk-lib>=2.72.0
 constructs>=10.0.0
 boto3>=1.20.0

--- a/resourcetagging/tagging_stack.py
+++ b/resourcetagging/tagging_stack.py
@@ -19,6 +19,7 @@ class ResourceTaggingStack(Stack):
 
         # set parameters
         tags = CfnParameter(self, "tags", type="String", description="tag name and value with json format.")
+        identityRecording = CfnParameter(self, "identityRecording", type="String", default="true", description="Defines if the tool records the requester identity as a tag.")
 
         # create role for lambda function
         lambda_role = _iam.Role(self, "lambda_role",
@@ -47,7 +48,8 @@ class ResourceTaggingStack(Stack):
                                     function_name="resource-tagging-automation-function",
                                     role=lambda_role,
                                     environment={
-                                        "tags": tags.value_as_string
+                                        "tags": tags.value_as_string,
+                                        "identityRecording": identityRecording.value_as_string
                                     }
                         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is adding a feature to record the user Identity and role name (if used) as a tag during lambda execution. This is a very common ask to better identify resources ownership and better cost allocation.
The feature can be disabled in case there are some concerns through a parameter in CDK.

I'm also modifying the readme.md file to document the process of disabling it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
